### PR TITLE
Avoids accessing 4.x symbols on 3.x platforms.

### DIFF
--- a/iCadeTest/iCade/iCadeReaderView.m
+++ b/iCadeTest/iCade/iCadeReaderView.m
@@ -40,14 +40,16 @@ static const char *OFF_STATES = "eczqtrfnmpgv";
     self = [super initWithFrame:frame];
     inputView = [[UIView alloc] initWithFrame:CGRectZero];
     
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didEnterBackground) name:UIApplicationDidEnterBackgroundNotification object:nil];
+	if (&UIApplicationDidEnterBackgroundNotification)
+	    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didEnterBackground) name:UIApplicationDidEnterBackgroundNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
     
     return self;
 }
 
 - (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
+	if (&UIApplicationDidEnterBackgroundNotification)
+	    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
     [super dealloc];
 }


### PR DESCRIPTION
With these small changes the iCadeReaderView class can be included in
programs supporting 3.x compatibility without affecting behaviour for
4.x and above.
